### PR TITLE
Add j2y and bside_gmbh NFS mounts to n8n

### DIFF
--- a/the-lab/apps/n8n/templates/nfs-bside-gmbh-pv.yaml
+++ b/the-lab/apps/n8n/templates/nfs-bside-gmbh-pv.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nfs-n8n-bside-gmbh
+  labels:
+    app: n8n
+    storage.type: nfs
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: nfs
+  mountOptions:
+    - nfsvers=4
+    - proto=tcp
+    - hard
+    - intr
+    - rsize=65536
+    - wsize=65536
+    - timeo=600
+    - retrans=2
+  nfs:
+    server: mercury.local
+    path: '/volume1/bside_gmbh'

--- a/the-lab/apps/n8n/templates/nfs-bside-gmbh-pvc.yaml
+++ b/the-lab/apps/n8n/templates/nfs-bside-gmbh-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-n8n-bside-gmbh
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: nfs
+  resources:
+    requests:
+      storage: 10Gi
+  volumeName: nfs-n8n-bside-gmbh

--- a/the-lab/apps/n8n/templates/nfs-j2y-pv.yaml
+++ b/the-lab/apps/n8n/templates/nfs-j2y-pv.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nfs-n8n-j2y
+  labels:
+    app: n8n
+    storage.type: nfs
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: nfs
+  mountOptions:
+    - nfsvers=4
+    - proto=tcp
+    - hard
+    - intr
+    - rsize=65536
+    - wsize=65536
+    - timeo=600
+    - retrans=2
+  nfs:
+    server: mercury.local
+    path: '/volume1/j2y'

--- a/the-lab/apps/n8n/templates/nfs-j2y-pvc.yaml
+++ b/the-lab/apps/n8n/templates/nfs-j2y-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-n8n-j2y
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: nfs
+  resources:
+    requests:
+      storage: 10Gi
+  volumeName: nfs-n8n-j2y

--- a/the-lab/apps/n8n/values.yaml
+++ b/the-lab/apps/n8n/values.yaml
@@ -138,7 +138,7 @@ n8n:
       # v2.0: Allow access to NFS data mount in addition to default ~/.n8n-files
       # /tmp is required for the Git node to clone repositories
       N8N_RESTRICT_FILE_ACCESS_TO:
-        value: '/home/node/.n8n;/home/node/nfs-data;/tmp'
+        value: '/home/node/.n8n;/home/node/nfs-data;/home/node/nfs-j2y;/home/node/nfs-bside-gmbh;/tmp'
       # v2.0: env var access in Code nodes blocked by default — re-enable if workflows need it
       N8N_BLOCK_ENV_ACCESS_IN_NODE:
         value: 'false'
@@ -188,6 +188,12 @@ n8n:
       - name: nfs-n8n-data
         persistentVolumeClaim:
           claimName: nfs-n8n-data
+      - name: nfs-n8n-j2y
+        persistentVolumeClaim:
+          claimName: nfs-n8n-j2y
+      - name: nfs-n8n-bside-gmbh
+        persistentVolumeClaim:
+          claimName: nfs-n8n-bside-gmbh
     #    - name: db-ca-cert
     #      secret:
     #        secretName: db-ca
@@ -198,6 +204,12 @@ n8n:
     extraVolumeMounts:
       - name: nfs-n8n-data
         mountPath: /home/node/nfs-data
+        readOnly: false
+      - name: nfs-n8n-j2y
+        mountPath: /home/node/nfs-j2y
+        readOnly: false
+      - name: nfs-n8n-bside-gmbh
+        mountPath: /home/node/nfs-bside-gmbh
         readOnly: false
     #    - name: db-ca-cert
     #      mountPath: /etc/ssl/certs/postgresql


### PR DESCRIPTION
## Summary
- Mount two additional NFS shares from mercury.local into the n8n pod: `/volume1/j2y` and `/volume1/bside_gmbh`
- Add PV/PVC pairs following the existing n8n NFS pattern
- Extend `N8N_RESTRICT_FILE_ACCESS_TO` so workflows can read and write files on the new mounts

## Test plan
- [ ] ArgoCD syncs the n8n application successfully
- [ ] New PVs/PVCs bind (`nfs-n8n-j2y`, `nfs-n8n-bside-gmbh`)
- [ ] n8n pod restarts and mounts appear at `/home/node/nfs-j2y` and `/home/node/nfs-bside-gmbh`
- [ ] Verify file access from a workflow or exec into the pod